### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/777abhi/markdown-based-pm/security/code-scanning/2](https://github.com/777abhi/markdown-based-pm/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. For a semantic-release workflow, the minimum required is usually `contents: write` (to create tags and releases). If the workflow also creates or comments on issues or pull requests, you may need to add `issues: write` or `pull-requests: write`. As a minimal starting point, set `contents: write` at the job level (under `release:`) to limit the token's scope. This change should be made in `.github/workflows/release.yml`, directly under the `release:` job definition (after `runs-on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
