### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,4 +1,6 @@
 name: Markdown Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/777abhi/markdown-based-pm/security/code-scanning/1](https://github.com/777abhi/markdown-based-pm/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents (to check out code and lint markdown files), set `contents: read` at the workflow level (top-level, after the `name` and before `on`). This ensures all jobs in the workflow inherit these minimal permissions unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
